### PR TITLE
Adds #{attribute}_by_sym and #{attribute}_const_for convenience methods

### DIFF
--- a/lib/flexible_enum/potential_values_configurator.rb
+++ b/lib/flexible_enum/potential_values_configurator.rb
@@ -15,13 +15,8 @@ module FlexibleEnum
         end
 
         define_singleton_method("#{attribute_name}_value_for") do |sym_string_or_const|
-          if [String, Symbol].include?(sym_string_or_const.class)
-            element = send(:"#{attribute_name.to_s.pluralize}_by_sym")[:"#{sym_string_or_const.downcase}"]
-          else
-            matching_elements = send(attribute_name.to_s.pluralize).select { |e| e.value == sym_string_or_const }
-            element = matching_elements[0] if matching_elements.length > 0
-          end
-
+          element = send(:"#{attribute_name.to_s.pluralize}_by_sym")[:"#{sym_string_or_const.to_s.downcase}"]
+          element ||= send(attribute_name.to_s.pluralize).select { |e| e.value == sym_string_or_const }.first
           raise("Unknown enumeration element: #{sym_string_or_const}") if !element
           element.value
         end

--- a/spec/usage_spec.rb
+++ b/spec/usage_spec.rb
@@ -16,6 +16,11 @@ class CashRegister
     opened 0, :setter => :open!
     closed 1, :setter => :close!
   end
+
+  flexible_enum :manufacturer do
+    honeywell "Honeywell"
+    sharp "Sharp"
+  end
 end
 
 class NotACashRegister
@@ -195,6 +200,7 @@ describe "the usage of flexible_enum when specifying a namespace" do
     expect { CashRegister.status_value_for("bad_string") }.to raise_error("Unknown enumeration element: bad_string")
     expect { CashRegister.status_value_for(666) }.to raise_error("Unknown enumeration element: 666")
     CashRegister.drawer_position_value_for(:opened).should == CashRegister::DrawerPositions::OPENED
+    CashRegister.manufacturer_value_for("honeywell").should == "Honeywell"
   end
 end
 


### PR DESCRIPTION
The _by_sym was originally part of that message types refactoring from ages ago.  I added _const_for to support looking up constants in a flexible_enum by symbol.
