### PR TITLE
Makes scopes first remove any conflicting where scopes.

### DIFF
--- a/lib/flexible_enum/scope_configurator.rb
+++ b/lib/flexible_enum/scope_configurator.rb
@@ -5,7 +5,7 @@ module FlexibleEnum
 
       elements.each do |element_name, element_config|
         add_class_method(scope_name(element_name)) do
-          where(configurator.attribute_name => element_config[:value])
+          unscope(:where => configurator.attribute_name).where(configurator.attribute_name => element_config[:value])
         end
       end
     end

--- a/spec/scopes_spec.rb
+++ b/spec/scopes_spec.rb
@@ -17,4 +17,11 @@ describe "scopes" do
     expect(CashRegister.drawer_position_opened).to contain_exactly(opened)
     expect(CashRegister.drawer_position_closed).to contain_exactly(closed)
   end
+
+  it "builds scopes that aren't affected by default scopes" do
+    WithDefaultScope.new.tap(&:active!)
+    passive = WithDefaultScope.new.tap(&:passive!)
+
+    expect(WithDefaultScope.passive).to contain_exactly(passive)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,10 @@ ActiveRecord::Schema.define do
     t.string   "manufacturer"
     t.integer  "drawer_position"
   end
+
+  create_table "with_default_scopes" do |t|
+    t.integer "status"
+  end
 end
 
 class CashRegister < ActiveRecord::Base
@@ -42,4 +46,13 @@ class CashRegister < ActiveRecord::Base
     honeywell "HON"
     sharp "SHCAY"
   end
+end
+
+class WithDefaultScope < ActiveRecord::Base
+  flexible_enum :status do
+    active  0
+    passive 1
+  end
+
+  default_scope { where(status: ACTIVE) }
 end


### PR DESCRIPTION
DO NOT MERGE. This will _break_ uses with ActiveRecord 3.x. It will work with AR >= 4.0 and is necessary for AR 4.1.x. So, the point is not to merge this into master but to keep it as a separate branch (or to make the code conditional, if that's what people prefer).

In AR 4.1.0, if you have the following model:

``` ruby
class User < ActiveRecord::Base
  flexible_enum :status do
    active 1,
    inactive 2
  end
end

default_scope -> { active }
```

... and then you try to get inactive users with `User.inactive`, AR 4.1.0 will generate a query with a contradiction: `... WHERE status = 1 AND status = 2`. It's necessary first to remove the conflicting scope.
