### PR TITLE
Expose a .flexible_enums method on the target class

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ Configuration parameters passed to attribute options are saved even if they are 
       end
     end
 
-## Option Reflection
+## Option Introspection
 
-You may reflect on available options and their configuration parameters:
+You may introspect on available options and their configuration parameters:
 
     ary = EmailEvent.event_types
     ary.collect(&:name)       # => ["bounce", "dropped", "opened", "delivered"]
@@ -190,6 +190,25 @@ You may reflect on available options and their configuration parameters:
 This works particularly well with ActionView:
 
     options_from_collection_for_select(EmailEvent.event_types, "value", "human_name")
+
+## Enum Introspection
+
+You may retrieve a list of all defined `flexible_enum`s on a particular class:
+
+    class Car < ActiveRecord::Base
+      flexible_enum :status do
+        new  1
+        used 2
+      end
+
+      flexible_enum :car_type do
+        gas      1
+        hybrid   2
+        electric 3
+      end
+    end
+
+    Car.flexible_enums # => { status: Car.statuses, car_type: Car.car_types }
 
 ## Overriding Methods
 

--- a/lib/flexible_enum/mixin.rb
+++ b/lib/flexible_enum/mixin.rb
@@ -6,6 +6,10 @@ module FlexibleEnum
     extend ActiveSupport::Concern
 
     module ClassMethods
+      def flexible_enums
+        @flexible_enums ||= {}
+      end
+
       def flexible_enum(attribute_name, attribute_options = {}, &config)
         # Methods are defined on the feature module which in turn is mixed in to the target class
         feature_module = Module.new do |m|
@@ -35,6 +39,8 @@ module FlexibleEnum
 
         # Add functionality to target inheritance chain
         send(:include, feature_module)
+
+        flexible_enums[attribute_name] = public_send("#{attribute_name.to_s.pluralize}_by_sym")
       end
     end
   end

--- a/spec/enum_introspection_spec.rb
+++ b/spec/enum_introspection_spec.rb
@@ -1,0 +1,9 @@
+require "spec_helper"
+
+describe "target class exposing flexible_enums" do
+  it "allows consumers to find all defined flexible_enums" do
+    expect(CashRegister.flexible_enums[:status].keys).to eq([:unknown, :not_active, :active, :alarm, :fill, :empty])
+    expect(CashRegister.flexible_enums[:drawer_position].keys).to eq([:opened, :closed])
+    expect(CashRegister.flexible_enums[:manufacturer].keys).to eq([:honeywell, :sharp])
+  end
+end


### PR DESCRIPTION
This new class method returns a list of defined `flexible_enum`s that everyone else can use.

I plan on using this to enhance a new seeding feature coming to WBID, but I see it being useful in other places.
