### PR TITLE
Return nil for name methods, whenever the flex enum value is nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,22 @@ Humanized versions of attributes are available. This is convenient for displayin
     Car.human_fuel_type(0) # => "Gasoline"
     Car.fuel_types.collect(&:human_name) # => ["Gasoline", "Diesel", "Electric"]
 
+If the flexible enum value is `nil`, the humanized name will also be `nil`:
+
+    c = Car.new(fuel_type: nil)
+    c.human_fuel_type # => nil
+
 ## Name Method
 
 The name of the attribute value is available. This allows you to grab the stringified version of the name of the value.
 
     c = Car.new(fuel_type: Car::CARBON_EMITTER)
     c.fuel_type_name # => "carbon_emitter"
+
+If the flexible enum value is `nil`, the name will also be `nil`:
+
+    c = Car.new(fuel_type: nil)
+    c.fuel_type_name # => nil
 
 ## Namespaced Attributes
 

--- a/lib/flexible_enum/name_configurator.rb
+++ b/lib/flexible_enum/name_configurator.rb
@@ -19,12 +19,20 @@ module FlexibleEnum
     end
 
     def name_for(value)
-      element_info(value).first.to_s
+      if value
+        element_info(value).first.to_s
+      else
+        nil
+      end
     end
 
     def human_name_for(value)
-      element_name, element_config = element_info(value)
-      element_config[:human_name] || element_name.to_s.humanize
+      if value
+        element_name, element_config = element_info(value)
+        element_config[:human_name] || element_name.to_s.humanize
+      else
+        nil
+      end
     end
 
     private

--- a/spec/name_values_spec.rb
+++ b/spec/name_values_spec.rb
@@ -7,6 +7,8 @@ describe "name values" do
     expect(register.status_name).to eq("unknown")
     register.status = CashRegister::NOT_ACTIVE
     expect(register.status_name).to eq("not_active")
+    register.status = nil
+    expect(register.status_name).to be_nil
   end
 
   it "retrieves the human name of the current value" do
@@ -15,6 +17,8 @@ describe "name values" do
     expect(register.human_status).to eq("Unknown")
     register.status = CashRegister::NOT_ACTIVE
     expect(register.human_status).to eq("Not active")
+    register.status = nil
+    expect(register.human_status).to be_nil
   end
 
   it "retrieves human names for available options" do


### PR DESCRIPTION
Before this change, if `status` was set to `nil`, `CashRegister.human_status` would error out with

```
undefined method `first' for nil:NilClass
```

Whereas now it will return `nil`.
