### PR TITLE
Require ActiveSupport ~> 4.1

### DIFF
--- a/flexible_enum.gemspec
+++ b/flexible_enum.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 3.0"
+  spec.add_dependency "activesupport", "~> 4.1"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
4.0 is actually the required minimum version of ActiveSupport but only 4.1 and 4.2 are supported. The plan moving forward is to add Rails 5.0.0.pre to Appraisal as soon as it's cut.