### PR TITLE
Provide a method to access all of an enum's options

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ CashRegister.drawer_position_closed # => CashRegister.where(drawer_position: 1)
 
 ## Custom Options
 
-Configuration parameters passed to attribute options are saved even if they are unknown. Getting at custom configuration parameters is a little clumsy at the moment but this can still be useful in some cases:
+Configuration parameters passed to attribute options are saved even if they are unknown.
 
 ```ruby
 class EmailEvent < ActiveRecord::Base
@@ -213,11 +213,13 @@ class EmailEvent < ActiveRecord::Base
     opened    3, processor_class: EmailOpenedProcessor
     delivered 4, processor_class: DeliveryProcessor
   end
-
-  def process
-    class.event_types[event_type][:processor_class].new(self).process
-  end
 end
+```
+
+Custom configuration parameters are available as an instance method on the object as well.
+```
+e = EmailEvent.new(event_type: 1)
+e.event_type_details # => { processor_class: RejectedProcessor, value: 1 }
 ```
 
 ## Option Introspection

--- a/lib/flexible_enum.rb
+++ b/lib/flexible_enum.rb
@@ -6,7 +6,7 @@ module FlexibleEnum
   autoload :Configuration, 'flexible_enum/configuration'
   autoload :AbstractConfigurator, 'flexible_enum/abstract_configurator'
   autoload :ConstantConfigurator, 'flexible_enum/constant_configurator'
-  autoload :NameConfigurator, 'flexible_enum/name_configurator'
+  autoload :IdentityConfigurator, 'flexible_enum/identity_configurator'
   autoload :QuestionMethodConfigurator, 'flexible_enum/question_method_configurator'
   autoload :SetterMethodConfigurator, 'flexible_enum/setter_method_configurator'
   autoload :ScopeConfigurator, 'flexible_enum/scope_configurator'

--- a/lib/flexible_enum/identity_configurator.rb
+++ b/lib/flexible_enum/identity_configurator.rb
@@ -1,7 +1,12 @@
 module FlexibleEnum
-  class NameConfigurator < AbstractConfigurator
+  class IdentityConfigurator < AbstractConfigurator
     def apply
       configurator = self
+
+      add_instance_method("#{attribute_name}_details") do
+        value = send(configurator.attribute_name)
+        configurator.details_for(value)
+      end
 
       add_instance_method("#{attribute_name}_name") do
         value = send(configurator.attribute_name)
@@ -21,6 +26,14 @@ module FlexibleEnum
     def name_for(value)
       if value
         element_info(value).first.to_s
+      else
+        nil
+      end
+    end
+
+    def details_for(value)
+      if value
+        element_info(value).try(:last)
       else
         nil
       end

--- a/lib/flexible_enum/mixin.rb
+++ b/lib/flexible_enum/mixin.rb
@@ -28,7 +28,7 @@ module FlexibleEnum
 
         # Configure the target object for the given attribute
         configurators = [ConstantConfigurator,
-                         NameConfigurator,
+                         IdentityConfigurator,
                          QuestionMethodConfigurator,
                          SetterMethodConfigurator,
                          ScopeConfigurator,

--- a/spec/identity_values_spec.rb
+++ b/spec/identity_values_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
-describe "name values" do
+describe "identity values" do
+  it "retrieves the details for the current value" do
+    register = CashRegister.new
+    register.status = CashRegister::NOT_ACTIVE
+
+    expect(register.status_details).to eq(my_custom_option: "Nothing to see here", value: 10)
+  end
+
   it "retrieves the name for the current value" do
     register = CashRegister.new
     register.status = CashRegister::UNKNOWN


### PR DESCRIPTION
Previously getting at custom configuration parameters was really nasty. This provides a more convenient access point.