### PR TITLE
Have setter methods raise exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Current release (in development)
 --------------------------------
 
-* ...
+* Enum setter methods raise exceptions in accordance with Rails conventions for bang (`!`) methods. (#27, @aprescott)
 
 0.3.0
 -----

--- a/lib/flexible_enum/setter_method_configurator.rb
+++ b/lib/flexible_enum/setter_method_configurator.rb
@@ -12,7 +12,7 @@ module FlexibleEnum
           time = Time.now.utc
           attributes["#{timestamp_attribute_name}_on".to_sym] = time.to_date if self.class.attribute_method?("#{timestamp_attribute_name}_on")
           attributes["#{timestamp_attribute_name}_at".to_sym] = time if self.class.attribute_method?("#{timestamp_attribute_name}_at")
-          update_attributes(attributes)
+          update_attributes!(attributes)
         end
       end
     end

--- a/spec/setter_methods_spec.rb
+++ b/spec/setter_methods_spec.rb
@@ -60,9 +60,9 @@ describe "setter methods" do
 
       specify { expect(register).to_not be_valid }
 
-      it "does not persist any attribute changes" do
-        register.empty!
-        register.close!
+      it "raises and does not persist any changes" do
+        expect { register.empty! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Required attribute can't be blank")
+        expect { register.close! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Required attribute can't be blank")
 
         expect(register).to be_empty
         expect(register).to be_closed

--- a/spec/setter_methods_spec.rb
+++ b/spec/setter_methods_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe "setter methods" do
   subject(:register) { CashRegister.new }
 
+  before { register.save! }
+
   it "adds default bang methods for setting a new value" do
     expect(register.status).to be_nil
     register.active!
@@ -20,14 +22,16 @@ describe "setter methods" do
   end
 
   describe "updating database" do
-    let!(:now) { Time.now }
+    let!(:now) { Time.at(Time.now.to_i) }
     let(:updates) { [] }
 
     before { allow(Time).to receive(:now).and_return(now) }
 
-    it "immediately dispatches a validation-free update" do
+    it "performs an update on the relevant attribute" do
       register.active!
       register.close!
+
+      register.reload
 
       expect(register).to be_active
       expect(register).to be_closed
@@ -35,14 +39,40 @@ describe "setter methods" do
 
     it "updates default timestamp columns with the current date and time" do
       register.fill!
+
+      register.reload
+
       expect(register).to be_full
       expect(register.full_at).to eq(now)
     end
 
     it "updates custom timestamp columns with the current date and time" do
       register.empty!
+
+      register.reload
+
       expect(register).to be_empty
       expect(register.emptied_at).to eq(now)
+    end
+
+    context "when there are validation errors" do
+      before { register.include_validations = true }
+
+      specify { expect(register).to_not be_valid }
+
+      it "does not persist any attribute changes" do
+        register.empty!
+        register.close!
+
+        expect(register).to be_empty
+        expect(register).to be_closed
+
+        register.reload
+
+        expect(register).to_not be_empty
+        expect(register).to_not be_closed
+        expect(register.emptied_at).to be_nil
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,10 @@ class CashRegister < ActiveRecord::Base
     honeywell "HON"
     sharp "SHCAY"
   end
+
+  attr_accessor :include_validations, :required_attribute
+
+  validates_presence_of :required_attribute, if: -> { include_validations }
 end
 
 class WithDefaultScope < ActiveRecord::Base


### PR DESCRIPTION
There are two commits here:
1. Some backfilling of tests for the case where `update_attributes` doesn't save successfully.
2. The change for this PR, to use `update_attributes!` instead of `update_attributes`.
### Back-filled tests

Existing specs against setter methods are changed so that they're working with a persisted record. Because the record is now persisted, we can correctly `reload` the record to verify that, e.g., `empty!` really does persist the flexible enum value, and its related timestamps. Without this assertion, it's possible that `update_attributes()` is actually failing to persist the new values and is only updating the value in memory.

Note that the previous wording of "validation-free" was mistaken: `update_attributes()` (plural) does not skip validations (as it's an alias for `update()`). (`update_attribute()`, however, does skip validations.)
### Raising when there are problems saving

Consider the following flexible enum configuration.

``` ruby
class User < ActiveRecord::Base
  flexible_enum :status do
    active 1
    inactive 2, setter: :deactivate!
  end
end
```

When a `User` is deactivated, it's likely that you'd see something like:

``` ruby
if deactivation_requested
  current_user.deactivate!
end
```

Because of the naming of the method (with a bang) and existing Rails conventions, it's unlikely that you'd check the result of `current_user.deactivate!` to see if it was successful.

Moreover, there are situations where you wish to clear out related records for all deactivations. You can currently do that by wrapping the setter:

``` ruby
def deactivate!
  transaction do
    self.foos.each(&:remove!)
    self.bars.each(&:remove!)

    super
  end
end
```

An expectation with this code is that `super` will `raise` if there are any problems, rolling back the transaction. Except what actually would happen currently is that `super` would return `false` (through `update_attributes()`, no `!`), the transaction would commit, and now the user is still `ACTIVE` but the `foos` and `bars` were removed.

This changes all setter methods to instead `raise` when there are problems with the update.
