### PR TITLE
Revert "Makes scopes first remove any conflicting where scopes."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Current release (in development)
 --------------------------------
 
+*   Revert #4. Scopes provided by flexible_enum no longer attempt to overwrite pre-existing `WHERE` conditions on the enum column. #30
+
+    *Alex Robbin*
+
 * ...
 
 0.3.0

--- a/lib/flexible_enum/scope_configurator.rb
+++ b/lib/flexible_enum/scope_configurator.rb
@@ -5,7 +5,7 @@ module FlexibleEnum
 
       elements.each do |element_name, element_config|
         add_class_method(scope_name(element_name)) do
-          unscope(:where => configurator.attribute_name).where(configurator.attribute_name => element_config[:value])
+          where(configurator.attribute_name => element_config[:value])
         end
       end
     end

--- a/spec/scopes_spec.rb
+++ b/spec/scopes_spec.rb
@@ -17,11 +17,4 @@ describe "scopes" do
     expect(CashRegister.drawer_position_opened).to contain_exactly(opened)
     expect(CashRegister.drawer_position_closed).to contain_exactly(closed)
   end
-
-  it "builds scopes that aren't affected by default scopes" do
-    WithDefaultScope.new.tap(&:active!)
-    passive = WithDefaultScope.new.tap(&:passive!)
-
-    expect(WithDefaultScope.passive).to contain_exactly(passive)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,10 +21,6 @@ ActiveRecord::Schema.define do
     t.string   "manufacturer"
     t.integer  "drawer_position"
   end
-
-  create_table "with_default_scopes" do |t|
-    t.integer "status"
-  end
 end
 
 class CashRegister < ActiveRecord::Base
@@ -46,13 +42,4 @@ class CashRegister < ActiveRecord::Base
     honeywell "HON"
     sharp "SHCAY"
   end
-end
-
-class WithDefaultScope < ActiveRecord::Base
-  flexible_enum :status do
-    active  0
-    passive 1
-  end
-
-  default_scope { where(status: ACTIVE) }
 end


### PR DESCRIPTION
After much contemplation, the decision has been made to not try and automatically resolve contradictory `WHERE` clauses that are introduced by `default_scope` or any other scope. While in this simple case:

```ruby
class User < ActiveRecord::Base
  default_scope -> { active }

  flexible_enum :status do
    active 1
    inactive 2
  end
end
```

Having this gem know to remove the `active` scope when calling `User.inactive` is a very nice feature. The worry comes when you have this case:

```ruby
class User < ActiveRecord::Base
  default_scope -> { where.not(status: INACTIVE) }

  flexible_enum :status do
    pending 0
    active 1
    inactive 2
  end
end
```

`User.pending` is going to remove the `where.not(status: INACTIVE)` condition when that might not be the expected behavior.

Additionally, `unscope` has unintended consequences that become very difficult to work around. Specifically, `unscope(where: :status)` will remove *any* `where(status: ...)` condition, regardless of the table it is called on.

```ruby
class User < ActiveRecord::Base
  flexible_enum :status do
    active 1
    inactive 2
  end

  has_one :user_profile
end

class UserProfile < ActiveRecord::Base
  flexible_enum :status do
    active 1
    inactive 2
  end

  belongs_to :user
end
```

`User.joins(:user_profile).merge(UserProfile.active).active` will remove the `UserProfile.active` scope before adding the `User.active` scope.

Reverts #4