### PR TITLE
Add activerecord as a development dependency

### DIFF
--- a/flexible_enum.gemspec
+++ b/flexible_enum.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", "~> 4.1"
 
+  spec.add_development_dependency "activerecord"
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "fury"


### PR DESCRIPTION
Prior to this change, running `bundle install` and then `bundle exec rspec` produced the error:

```
spec/spec_helper.rb:2:in `require': cannot load such file -- active_record (LoadError)
```

In order to run tests successfully, add `activerecord` as a dev dependency.

Also, although it's still possible to run the specs with `appraisal rspec` (since the `Appraisals` file includes `gem rails`), I think it makes sense to include `activerecord` as a development dependency. Using `rspec` locally makes development easier and faster.