### PR TITLE
Add Inverse Scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Current release (in development)
 --------------------------------
 
-* ...
+* Add inverse scopes. (#32, @zfletch)
 
 0.4.0
 -----

--- a/README.md
+++ b/README.md
@@ -202,6 +202,24 @@ CashRegister.drawer_position_opened # => CashRegister.where(drawer_position: 0)
 CashRegister.drawer_position_closed # => CashRegister.where(drawer_position: 1)
 ```
 
+Inverse scopes can be added by setting the :inverse configuration parameter:
+
+```ruby
+class Car < ActiveRecord::Base
+  flexible_enum :fuel_type do
+    gasoline 0
+    diesel   1
+    electric 2, inverse: :carbon_emitter
+  end
+end
+
+gas = Car.create(fuel_type: Car::GASOLINE)
+diesel = Car.create(fuel_type: Car::DIESEL)
+electric = Car.create(fuel_type: Car::ELECTRIC)
+
+Car.carbon_emitter # => [gasoline, diesel]
+```
+
 ### Note about default scopes
 
 Be careful when using default scopes on FlexibleEnum columns. Since FlexibleEnum provides scopes for enum values, setting a `default_scope` on a FlexibleEnum column will result in conflicts. For example, given this model:

--- a/lib/flexible_enum/scope_configurator.rb
+++ b/lib/flexible_enum/scope_configurator.rb
@@ -7,6 +7,12 @@ module FlexibleEnum
         add_class_method(scope_name(element_name)) do
           where(configurator.attribute_name => element_config[:value])
         end
+
+        if element_config[:inverse]
+          add_class_method(scope_name(element_config[:inverse])) do
+            where.not(configurator.attribute_name => element_config[:value])
+          end
+        end
       end
     end
 

--- a/spec/scopes_spec.rb
+++ b/spec/scopes_spec.rb
@@ -10,11 +10,26 @@ describe "scopes" do
     expect(CashRegister.unknown).to be_empty
   end
 
+  it "builds scopes for inverse elements" do
+    unknowns = CashRegister.create!(status: CashRegister::UNKNOWN)
+    actives = CashRegister.create!(status: CashRegister::ACTIVE)
+    alarms = CashRegister.create!(status: CashRegister::ALARM)
+
+    expect(CashRegister.known).to contain_exactly(actives, alarms)
+  end
+
   it "builds scopes with prefixed names for each namespaced element" do
     opened = CashRegister.new.tap(&:open!)
     closed = CashRegister.new.tap(&:close!)
 
     expect(CashRegister.drawer_position_opened).to contain_exactly(opened)
     expect(CashRegister.drawer_position_closed).to contain_exactly(closed)
+  end
+
+  it "builds inverse scopes with prefixed names for each namespaced element" do
+    opened = CashRegister.new.tap(&:open!)
+    closed = CashRegister.new.tap(&:close!)
+
+    expect(CashRegister.drawer_position_not_open).to contain_exactly(closed)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ class CashRegister < ActiveRecord::Base
   end
 
   flexible_enum :drawer_position, :namespace => "DrawerPositions" do
-    opened 0, setter: :open!
+    opened 0, setter: :open!, inverse: :not_open
     closed 1, setter: :close!
   end
 


### PR DESCRIPTION
FlexibleEnum already has the ability to create inverse predicate methods. For example:

```ruby
class Car < ActiveRecord::Base
  flexible_enum :fuel_type do
    gasoline 0
    diesel   1
    electric 2, inverse: :carbon_emitter
  end
end

c = Car.new
c.gasoline!
c.carbon_emitter? # => true
c.diesel!
c.carbon_emitter? # => true
c.electric!
c.carbon_emitter? # => false
```

This commit adds an inverse scope in addition to an inverse predicate method. For example:

```ruby
class Car < ActiveRecord::Base
  flexible_enum :fuel_type do
    gasoline 0
    diesel   1
    electric 2, inverse: :carbon_emitter
  end
end

gas = Car.create
gas.gasoline!

diesel = Car.create
diesel.diesel!

electric = Car.create
electric.electric!

Car.carbon_emitter # [gasoline, diesel]
```