### PR TITLE
Start running Travis tests in separate jobs for each Ruby + Rails version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 ---
 language: ruby
-rvm: 2.1.2
-before_script: bundle exec appraisal install
-script: bundle exec appraisal rspec
+rvm:
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
+gemfile:
+  - gemfiles/rails_4.1.gemfile
+  - gemfiles/rails_4.2.gemfile
+script: bundle exec rspec spec
+matrix:
+  fast_finish: true


### PR DESCRIPTION
I don't think it's worth splitting the matrix even more (ie. per Appraisal `gemfile`), but I can do that if that's what others prefer.